### PR TITLE
Fixes failing specs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 Gemfile.lock
 .bundle
 vendor
+derby.log

--- a/spec/inputs/jdbc_spec.rb
+++ b/spec/inputs/jdbc_spec.rb
@@ -40,10 +40,10 @@ describe "jdbc" do
       plugin.run(q)
     end
     sleep 3
+    plugin.teardown
     runner.kill
     runner.join
     insist { q.size } == 2
-    plugin.teardown
     Timecop.return
   end
 


### PR DESCRIPTION
This PR make all specs to pass in a more consistent way as it was before, now all are green also in linux environments as our beloved jenkins.

The main problem was the time needed to kill the thread used to run the plugin within the test example, in our test environment it got kill slightly after 3 seconds passed (the desired time frame), so at the end this end up on not having the desired number of events.

To "workaround" this situation for now I propose to call the teardown method just after the sleep call, so the scheduler is off, and not rely on  thread.kill to stop the pipeline properly and on time.

I also added the generated logs to the gitignore file.

So what do you think @talevy ?