### PR TITLE
Clean up ruby-maven dependency

### DIFF
--- a/logstash-input-jdbc.gemspec
+++ b/logstash-input-jdbc.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'logstash', '>= 1.4.0', '< 2.0.0'
   s.add_runtime_dependency 'logstash-codec-plain'
   s.add_runtime_dependency 'sequel'
-  s.add_runtime_dependency 'ruby-maven', '3.1.1.0.8'
 
   s.add_development_dependency 'logstash-devutils'
   s.add_development_dependency 'timecop'


### PR DESCRIPTION
cleanup the usage of ruby maven as it's not really used here, and we also aim to not used it anymore in favor of having jars loaded within the gems.

Related to https://github.com/elastic/logstash/issues/2954