### PR TITLE
add jdbc fetch size param to queries

### DIFF
--- a/lib/logstash/inputs/jdbc.rb
+++ b/lib/logstash/inputs/jdbc.rb
@@ -42,6 +42,15 @@ require "yaml" # persistence
 # `clean_run` is set to true, this value will be ignored and `sql_last_start` will be
 # set to Jan 1, 1970, as if no query has ever been executed.
 #
+# ==== Dealing With Large Result-sets
+#
+# Many JDBC drivers use the `fetch_size` parameter to limit how many
+# results are pre-fetched at a time from the cursor into the client's cache
+# before retrieving more results from the result-set. This is configured in
+# this plugin using the `jdbc_fetch_size` configuration option. No fetch size
+# is set by default in this plugin, so the specific driver's default size will 
+# be used.
+#
 # ==== Usage:
 #
 # Here is an example of setting up the plugin to fetch data from a MySQL database.

--- a/lib/logstash/plugin_mixins/jdbc.rb
+++ b/lib/logstash/plugin_mixins/jdbc.rb
@@ -45,6 +45,9 @@ module LogStash::PluginMixins::Jdbc
     # JDBC page size
     config :jdbc_page_size, :validate => :number, :default => 100000
 
+    # JDBC fetch size. if not provided, respective driver's default will be used
+    config :jdbc_fetch_size, :validate => :number
+
     # Connection pool configuration.
     # Validate connection before use.
     config :jdbc_validate_connection, :validate => :boolean, :default => false
@@ -67,6 +70,7 @@ module LogStash::PluginMixins::Jdbc
       @database.extension(:connection_validator)
       @database.pool.connection_validation_timeout = @jdbc_validation_timeout
     end
+    @database.fetch_size = @jdbc_fetch_size unless @jdbc_fetch_size.nil?
     begin
       @database.test_connection
     rescue Sequel::DatabaseConnectionError => e

--- a/spec/inputs/jdbc_spec.rb
+++ b/spec/inputs/jdbc_spec.rb
@@ -260,4 +260,34 @@ describe "jdbc" do
       expect(File).not_to exist(settings["last_run_metadata_path"])
     end
   end
+
+  context "when setting fetch size" do
+
+    let(:settings) do
+      {
+        "statement" => "SELECT * from test_table",
+        "jdbc_fetch_size" => 1
+      }
+    end
+
+    let(:num_rows) { 10 }
+
+    before do
+      num_rows.times do
+        db[:test_table].insert(:num => 1, :created_at => Time.now.utc)
+      end
+
+      plugin.register
+    end
+
+    after do
+      plugin.teardown
+    end
+
+    it "should fetch all rows" do
+      plugin.run(queue)
+      expect(queue.size).to eq(num_rows)
+    end
+
+  end
 end


### PR DESCRIPTION
This means slightly different things depending on the vendor and its JDBC driver implementation. Still collecting proven updated information about each vendor's implementation so this can be documented further