### PR TITLE
pass password as string to Sequel

### DIFF
--- a/lib/logstash/plugin_mixins/jdbc.rb
+++ b/lib/logstash/plugin_mixins/jdbc.rb
@@ -76,7 +76,7 @@ module LogStash::PluginMixins::Jdbc
   def jdbc_connect
     opts = {
       :user => @jdbc_user,
-      :password => @jdbc_password,
+      :password => @jdbc_password.nil? ? nil : @jdbc_password.value,
       :pool_timeout => @jdbc_pool_timeout
     }.merge(@sequel_opts)
     begin

--- a/spec/inputs/jdbc_spec.rb
+++ b/spec/inputs/jdbc_spec.rb
@@ -35,6 +35,12 @@ describe LogStash::Inputs::Jdbc do
       plugin.stop
     end
 
+    it "should register with password set" do
+      mixin_settings['jdbc_password'] = 'pass'
+      expect { plugin.register }.to_not raise_error
+      plugin.stop
+    end
+
     it "should stop without raising exception" do
       plugin.register
       expect { plugin.stop }.to_not raise_error


### PR DESCRIPTION
this issue was found with using Logstash's Password class to wrap the password string.

ref: https://github.com/logstash-plugins/logstash-input-jdbc/issues/62#issuecomment-150103578

this commit extracts the string value of the password and passes that to Sequel.