### PR TITLE
prevents multiple queries from being run at the same time.

### DIFF
--- a/lib/logstash/inputs/jdbc.rb
+++ b/lib/logstash/inputs/jdbc.rb
@@ -159,7 +159,7 @@ class LogStash::Inputs::Jdbc < LogStash::Inputs::Base
 
   def run(queue)
     if @schedule
-      @scheduler = Rufus::Scheduler.new
+      @scheduler = Rufus::Scheduler.new(:max_work_threads => 1)
       @scheduler.cron @schedule do
         execute_query(queue)
       end


### PR DESCRIPTION
Currently, if a query is still running while the scheduler
triggers a new query to be executed, the new query will be launched.
This means that two queries will be running at the same time, this can
cause consistency issues. By setting the max_work_threads to `1`, all
newly triggered queries will be added to a work queue within Rufus and
launched immedietly proceeding the completion of the existing pending
job.