### PR TITLE
Enable more the option to load more than one jar as part of JDBC drivers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.1.0
+  - [#85](https://github.com/logstash-plugins/logstash-input-jdbc/issues/85) make the jdbc_driver_library accept a list of elements separated by commas as in some situations we might need to load more than one jar/lib.
+
 ## 2.0.5
   - [#77](https://github.com/logstash-plugins/logstash-input-jdbc/issues/77) Time represented as RubyTime and not as Logstash::Timestamp
 

--- a/lib/logstash/plugin_mixins/jdbc.rb
+++ b/lib/logstash/plugin_mixins/jdbc.rb
@@ -96,7 +96,11 @@ module LogStash::PluginMixins::Jdbc
   private
   def load_drivers(drivers)
     drivers.each do |driver|
-      require driver
+      begin
+        require driver
+      rescue => e
+        @logger.error("Failed to load #{driver}", :exception => e)
+      end
     end
   end
 

--- a/lib/logstash/plugin_mixins/jdbc.rb
+++ b/lib/logstash/plugin_mixins/jdbc.rb
@@ -18,10 +18,11 @@ module LogStash::PluginMixins::Jdbc
 
   public
   def setup_jdbc_config
-    # JDBC driver library path to third party driver library.
+    # JDBC driver library path to third party driver library. In case of multiple libraries being
+    # required you can pass them separated by a comma.
     #
     # If not provided, Plugin will look for the driver class in the Logstash Java classpath.
-    config :jdbc_driver_library, :validate => :path
+    config :jdbc_driver_library, :validate => :string
 
     # JDBC driver class to load, for exmaple, "org.apache.derby.jdbc.ClientDriver"
     # NB per https://github.com/logstash-plugins/logstash-input-jdbc/issues/43 if you are using
@@ -92,12 +93,20 @@ module LogStash::PluginMixins::Jdbc
     end
   end
 
+  private
+  def load_drivers(drivers)
+    drivers.each do |driver|
+      require driver
+    end
+  end
+
   public
   def prepare_jdbc_connection
     require "java"
     require "sequel"
     require "sequel/adapters/jdbc"
-    require @jdbc_driver_library if @jdbc_driver_library
+    load_drivers(@jdbc_driver_library.split(",")) if @jdbc_driver_library
+    
     begin
       Sequel::JDBC.load_driver(@jdbc_driver_class)
     rescue Sequel::AdapterNotFound => e

--- a/logstash-input-jdbc.gemspec
+++ b/logstash-input-jdbc.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-input-jdbc'
-  s.version         = '2.0.5'
+  s.version         = '2.1.0'
   s.licenses = ['Apache License (2.0)']
   s.summary = "This example input streams a string at a definable interval."
   s.description = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"

--- a/spec/inputs/jdbc_spec.rb
+++ b/spec/inputs/jdbc_spec.rb
@@ -42,6 +42,20 @@ describe LogStash::Inputs::Jdbc do
       plugin.stop
     end
 
+    it "should load all drivers when passing an array" do
+      mixin_settings['jdbc_driver_library'] = '/foo/bar,/bar/foo'
+      expect(plugin).to receive(:load_drivers).with(['/foo/bar', '/bar/foo'])
+      plugin.register
+      plugin.stop
+    end
+
+    it "should load all drivers when using a single value" do
+      mixin_settings['jdbc_driver_library'] = '/foo/bar'
+      expect(plugin).to receive(:load_drivers).with(['/foo/bar'])
+      plugin.register
+      plugin.stop
+    end
+
     it "should stop without raising exception" do
       plugin.register
       expect { plugin.stop }.to_not raise_error


### PR DESCRIPTION
Hi, as stated in #85, in some cases you need to load more than one jar to load all jdbc drivers. This PR introduces this change by allowing you to separate each driver path with a comma. This is done like this so it does not break backwards compatibility with previous versions that accepted an string/path. In feature versions the config option should be changed to be an array as more suitable data type for this value. 

Fixes #85 