### PR TITLE
Increase log verbosity and levels of information

### DIFF
--- a/lib/logstash/plugin_mixins/jdbc.rb
+++ b/lib/logstash/plugin_mixins/jdbc.rb
@@ -73,8 +73,9 @@ module LogStash::PluginMixins::Jdbc
     # documentation page: https://github.com/jeremyevans/sequel/blob/master/doc/opening_databases.rdoc
     config :sequel_opts, :validate => :hash, :default => {}
 
-    # Log level at which to log SQL queries. The default value is info.
-    config :sql_log_level, :validate => :string, :default => "info"
+    # Log level at which to log SQL queries, the accepted values are the common ones fatal, error, warn,
+    # info and debug. The default value is info.
+    config :sql_log_level, :validate => [ "fatal", "error", "warn", "info", "debug" ], :default => "info"
   end
 
   private

--- a/lib/logstash/plugin_mixins/jdbc.rb
+++ b/lib/logstash/plugin_mixins/jdbc.rb
@@ -137,7 +137,7 @@ module LogStash::PluginMixins::Jdbc
     begin 
       parameters = symbolized_params(parameters)
       query = @database[statement, parameters]
-      @logger.debug? and @logger.debug("Executing JDBC query", :statement => statement, :parameters => parameters)
+      @logger.debug? and @logger.debug("Executing JDBC query", :statement => statement, :parameters => parameters, :count => query.count)
       @sql_last_start = Time.now.utc
 
       if @jdbc_paging_enabled

--- a/lib/logstash/plugin_mixins/jdbc.rb
+++ b/lib/logstash/plugin_mixins/jdbc.rb
@@ -72,6 +72,9 @@ module LogStash::PluginMixins::Jdbc
     # examples of vendor-specific options can be found in this
     # documentation page: https://github.com/jeremyevans/sequel/blob/master/doc/opening_databases.rdoc
     config :sequel_opts, :validate => :hash, :default => {}
+
+    # Log level at which to log SQL queries. The default value is info.
+    config :sql_log_level, :validate => :string, :default => "info"
   end
 
   private
@@ -122,7 +125,7 @@ module LogStash::PluginMixins::Jdbc
       #TODO return false and let the plugin raise a LogStash::ConfigurationError
       raise e
     end
-
+    @database.sql_log_level = @sql_log_level.to_sym
     @sql_last_start = Time.at(0).utc
   end # def prepare_jdbc_connection
 

--- a/lib/logstash/plugin_mixins/jdbc.rb
+++ b/lib/logstash/plugin_mixins/jdbc.rb
@@ -127,6 +127,7 @@ module LogStash::PluginMixins::Jdbc
       raise e
     end
     @database.sql_log_level = @sql_log_level.to_sym
+    @database.logger = @logger
     @sql_last_start = Time.at(0).utc
   end # def prepare_jdbc_connection
 


### PR DESCRIPTION
As requested in #61 this PR add more information to the debug log statements and also expose the sql_log_level variable from sequel.

Fixes #61