### PR TITLE
sql start time per run

### DIFF
--- a/lib/logstash/plugin_mixins/jdbc.rb
+++ b/lib/logstash/plugin_mixins/jdbc.rb
@@ -175,8 +175,8 @@ module LogStash::PluginMixins::Jdbc
     begin
       parameters = symbolized_params(parameters)
       query = @database[statement, parameters]
+      sql_last_start = Time.now.utc
       @logger.debug? and @logger.debug("Executing JDBC query", :statement => statement, :parameters => parameters, :count => query.count)
-      @sql_last_start = Time.now.utc
 
       if @jdbc_paging_enabled
         query.each_page(@jdbc_page_size) do |paged_dataset|
@@ -192,6 +192,8 @@ module LogStash::PluginMixins::Jdbc
       success = true
     rescue Sequel::DatabaseConnectionError, Sequel::DatabaseError => e
       @logger.warn("Exception when executing JDBC query", :exception => e)
+    else
+      @sql_last_start = sql_last_start
     end
     return success
   end


### PR DESCRIPTION
Two changes:
 - record sql last start time only on successful query execution. Mostly affected if scheduler is enabled that pulls latest updates based on the last start run. In case if query fails, current updates should be included with the next run
 - flush last start time after each query execution. Handy to trace the last time query has been executed

https://github.com/logstash-plugins/logstash-input-jdbc/issues/93