### PR TITLE
Implement force_lowercase_keys, code and tests. See issue 44

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.1.1
+  - [#44](https://github.com/logstash-plugins/logstash-input-jdbc/issues/44) add option to control the lowercase or not, of the column names.
+
 ## 2.1.0
   - [#85](https://github.com/logstash-plugins/logstash-input-jdbc/issues/85) make the jdbc_driver_library accept a list of elements separated by commas as in some situations we might need to load more than one jar/lib.
   - [#89](https://github.com/logstash-plugins/logstash-input-jdbc/issues/89) Set application timezone for cases where time fields in data have no timezone.

--- a/lib/logstash/inputs/jdbc.rb
+++ b/lib/logstash/inputs/jdbc.rb
@@ -12,13 +12,13 @@ require "yaml" # persistence
 #
 # ==== Drivers
 #
-# This plugin does not come packaged with JDBC driver libraries. The desired 
+# This plugin does not come packaged with JDBC driver libraries. The desired
 # jdbc driver library must be explicitly passed in to the plugin using the
 # `jdbc_driver_library` configuration option.
-# 
+#
 # ==== Scheduling
 #
-# Input from this plugin can be scheduled to run periodically according to a specific 
+# Input from this plugin can be scheduled to run periodically according to a specific
 # schedule. This scheduling syntax is powered by https://github.com/jmettraux/rufus-scheduler[rufus-scheduler].
 # The syntax is cron-like with some extensions specific to Rufus (e.g. timezone support ).
 #
@@ -29,16 +29,16 @@ require "yaml" # persistence
 # | `0 * * * *`                 | will execute on the 0th minute of every hour every day.
 # | `0 6 * * * America/Chicago` | will execute at 6:00am (UTC/GMT -5) every day.
 # |==========================================================
-#   
+#
 #
 # Further documentation describing this syntax can be found https://github.com/jmettraux/rufus-scheduler#parsing-cronlines-and-time-strings[here].
 #
 # ==== State
 #
-# The plugin will persist the `sql_last_start` parameter in the form of a 
-# metadata file stored in the configured `last_run_metadata_path`. Upon shutting down, 
+# The plugin will persist the `sql_last_start` parameter in the form of a
+# metadata file stored in the configured `last_run_metadata_path`. Upon shutting down,
 # this file will be updated with the current value of `sql_last_start`. Next time
-# the pipeline starts up, this value will be updated by reading from the file. If 
+# the pipeline starts up, this value will be updated by reading from the file. If
 # `clean_run` is set to true, this value will be ignored and `sql_last_start` will be
 # set to Jan 1, 1970, as if no query has ever been executed.
 #
@@ -48,17 +48,17 @@ require "yaml" # persistence
 # results are pre-fetched at a time from the cursor into the client's cache
 # before retrieving more results from the result-set. This is configured in
 # this plugin using the `jdbc_fetch_size` configuration option. No fetch size
-# is set by default in this plugin, so the specific driver's default size will 
+# is set by default in this plugin, so the specific driver's default size will
 # be used.
 #
 # ==== Usage:
 #
 # Here is an example of setting up the plugin to fetch data from a MySQL database.
 # First, we place the appropriate JDBC driver library in our current
-# path (this can be placed anywhere on your filesystem). In this example, we connect to 
+# path (this can be placed anywhere on your filesystem). In this example, we connect to
 # the 'mydb' database using the user: 'mysql' and wish to input all rows in the 'songs'
-# table that match a specific artist. The following examples demonstrates a possible 
-# Logstash configuration for this. The `schedule` option in this example will 
+# table that match a specific artist. The following examples demonstrates a possible
+# Logstash configuration for this. The `schedule` option in this example will
 # instruct the plugin to execute this input statement on the minute, every minute.
 #
 # [source,ruby]
@@ -77,9 +77,9 @@ require "yaml" # persistence
 # ----------------------------------
 #
 # ==== Configuring SQL statement
-# 
-# A sql statement is required for this input. This can be passed-in via a 
-# statement option in the form of a string, or read from a file (`statement_filepath`). File 
+#
+# A sql statement is required for this input. This can be passed-in via a
+# statement option in the form of a string, or read from a file (`statement_filepath`). File
 # option is typically used when the SQL statement is large or cumbersome to supply in the config.
 # The file option only supports one SQL statement. The plugin will only accept one of the options.
 # It cannot read a statement from a file as well as from the `statement` configuration parameter.
@@ -99,7 +99,7 @@ class LogStash::Inputs::Jdbc < LogStash::Inputs::Base
   config_name "jdbc"
 
   # If undefined, Logstash will complain, even if codec is unused.
-  default :codec, "plain" 
+  default :codec, "plain"
 
   # Statement to execute
   #
@@ -136,6 +136,9 @@ class LogStash::Inputs::Jdbc < LogStash::Inputs::Base
 
   # Whether to save state or not in last_run_metadata_path
   config :record_last_run, :validate => :boolean, :default => true
+
+  # Whether to force the lowercasing of identifier fields
+  config :lowercase_column_names, :validate => :boolean, :default => true
 
   public
 

--- a/lib/logstash/plugin_mixins/jdbc.rb
+++ b/lib/logstash/plugin_mixins/jdbc.rb
@@ -156,6 +156,11 @@ module LogStash::PluginMixins::Jdbc
     end
     @database.sql_log_level = @sql_log_level.to_sym
     @database.logger = @logger
+    if @lowercase_column_names
+      @database.identifier_output_method = :downcase
+    else
+      @database.identifier_output_method = :to_s
+    end
     @sql_last_start = Time.at(0).utc
   end # def prepare_jdbc_connection
 

--- a/logstash-input-jdbc.gemspec
+++ b/logstash-input-jdbc.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-input-jdbc'
-  s.version         = '2.1.0'
+  s.version         = '2.1.1'
   s.licenses = ['Apache License (2.0)']
   s.summary = "This example input streams a string at a definable interval."
   s.description = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
NOTES TO REVIEWERS:
- the Sequel library will downcase all fields by default.
- Some databases allow for mixed case field and table names e.g. MS SQL
- Introduce a new config option `force_lowercase_keys` defaulting to true for backward compatibility.
- In the test env, the Java Derby DB upper cases all identifiers, so this is tested for.

#44

@gmoskovicz @PhaedrusTheGreek - Merry Christmas! :smile: 