### PR TITLE
add jdbc_password_filepath parameter, with tests and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Reading data from MySQL:
 	    jdbc_connection_string => "jdbc:mysql://host:port/database"
 	    jdbc_user => "user"
 	    jdbc_password => "password"
+      # or jdbc_password_filepath => "/path/to/my/password_file"
 	    statement => "SELECT ..."
 	    jdbc_paging_enabled => "true"
 	    jdbc_page_size => "50000"

--- a/lib/logstash/inputs/jdbc.rb
+++ b/lib/logstash/inputs/jdbc.rb
@@ -185,6 +185,12 @@ class LogStash::Inputs::Jdbc < LogStash::Inputs::Base
     end
 
     @statement = File.read(@statement_filepath) if @statement_filepath
+
+    if (@jdbc_password_filepath and @jdbc_password)
+      raise(LogStash::ConfigurationError, "Only one of :jdbc_password, :jdbc_password_filepath may be set at a time.")
+    end
+
+    @jdbc_password = File.read(@jdbc_password_filepath).strip if @jdbc_password_filepath
   end # def register
 
   def run(queue)

--- a/lib/logstash/plugin_mixins/jdbc.rb
+++ b/lib/logstash/plugin_mixins/jdbc.rb
@@ -40,6 +40,9 @@ module LogStash::PluginMixins::Jdbc
     # JDBC password
     config :jdbc_password, :validate => :password
 
+    # JDBC password filename
+    config :jdbc_password_filepath, :validate => :path
+
     # JDBC enable paging
     #
     # This will cause a sql statement to be broken up into multiple queries.

--- a/spec/inputs/jdbc_spec.rb
+++ b/spec/inputs/jdbc_spec.rb
@@ -81,6 +81,41 @@ describe LogStash::Inputs::Jdbc do
     end
   end
 
+  context "when both jdbc_password and jdbc_password_filepath arguments are passed" do
+    let(:statement) { "SELECT * from test_table" }
+    let(:jdbc_password) { "secret" }
+    let(:jdbc_password_file_path) { Stud::Temporary.pathname }
+    let(:settings) { { "jdbc_password_filepath" => jdbc_password_file_path,
+                       "jdbc_password" => jdbc_password,
+                       "statement" => statement } }
+
+    it "should fail to register" do
+      expect{ plugin.register }.to raise_error(LogStash::ConfigurationError)
+    end
+  end
+
+  context "when jdbc_password is passed in from a file" do
+    let(:statement) { "SELECT * from test_table" }
+    let(:jdbc_password) { "secret" }
+    let(:jdbc_password_file_path) { Stud::Temporary.pathname }
+    let(:settings) { { "jdbc_password_filepath" => jdbc_password_file_path,
+                       "statement" => statement } }
+
+    before do
+      File.write(jdbc_password_file_path, jdbc_password)
+      plugin.register
+    end
+
+    after do
+      plugin.stop
+    end
+
+    it "should read in jdbc_password from file" do
+      expect(plugin.jdbc_password).to eq(jdbc_password)
+    end
+  end
+
+
   context "when neither statement and statement_filepath arguments are passed" do
     it "should fail to register" do
       expect{ plugin.register }.to raise_error(LogStash::ConfigurationError)


### PR DESCRIPTION
add `jdbc_password_filepath` parameter for reading password from an external file.

Must not be used when `jdbc_password` is set.


