### PR TITLE
Add an option to encode string values to a target encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.1.0
+  - Add an option to select the encoding data should be transform from,
+    this will make sure all strings read from the jdbc connector are
+    noremalized to be UTF-8 so no causing issues with later filters in LS.
 # 3.0.3
   - Added feature to read password from external file (#120).
 # 3.0.2

--- a/lib/logstash/inputs/jdbc.rb
+++ b/lib/logstash/inputs/jdbc.rb
@@ -160,6 +160,14 @@ class LogStash::Inputs::Jdbc < LogStash::Inputs::Base
   # Whether to force the lowercasing of identifier fields
   config :lowercase_column_names, :validate => :boolean, :default => true
 
+  # The character encoding used in this input. Examples include `UTF-8`
+  # and `cp1252`
+  #
+  # This setting is useful if some of your data is in `Latin-1` (aka `cp1252`)
+  # or in another character set other than `UTF-8`. After the conversion all data
+  # will be in `UTF-8` as the common encoding for LogStash pipeline.
+  config :charset, :validate => ::Encoding.name_list, :default => "UTF-8"
+
   public
 
   def register
@@ -191,6 +199,8 @@ class LogStash::Inputs::Jdbc < LogStash::Inputs::Base
     end
 
     @jdbc_password = File.read(@jdbc_password_filepath).strip if @jdbc_password_filepath
+
+    @converter = LogStash::Util::Charset.new(@charset)
   end # def register
 
   def run(queue)

--- a/lib/logstash/plugin_mixins/jdbc.rb
+++ b/lib/logstash/plugin_mixins/jdbc.rb
@@ -258,12 +258,11 @@ module LogStash::PluginMixins::Jdbc
   private
   #Stringify row keys and decorate values when necessary
   def extract_values_from(row)
-    Hash[row.map { |k, v| [k.to_s, decorate_value(v)] }]
+    Hash[row.map { |k, v| [k.to_s, decorate_value(convert(v))] }]
   end
 
   private
   def decorate_value(value)
-
     if value.is_a?(Time)
       # transform it to LogStash::Timestamp as required by LS
       LogStash::Timestamp.new(value)
@@ -272,7 +271,13 @@ module LogStash::PluginMixins::Jdbc
       # This is slower, so we put it in as a conditional case.
       LogStash::Timestamp.new(Time.parse(value.to_s))
     else
-      value  # no-op
+      value
     end
+  end
+
+  private
+  # make sure the encoding is uniform over fields
+  def convert(value)
+    value.is_a?(String) ? @converter.convert(value) : value
   end
 end

--- a/logstash-input-jdbc.gemspec
+++ b/logstash-input-jdbc.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-input-jdbc'
-  s.version         = '3.0.3'
+  s.version         = '3.1.0'
   s.licenses = ['Apache License (2.0)']
   s.summary = "This example input streams a string at a definable interval."
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/inputs/jdbc_spec.rb
+++ b/spec/inputs/jdbc_spec.rb
@@ -29,6 +29,7 @@ describe LogStash::Inputs::Jdbc do
     db.create_table :test_table do
       DateTime :created_at
       Integer  :num
+      String   :string
       DateTime :custom_time
     end
   end
@@ -871,5 +872,44 @@ describe LogStash::Inputs::Jdbc do
       expect { plugin.register }.to_not raise_error
       plugin.stop
     end
+  end
+
+  context "when encoding of some columns need to be changed" do
+
+    let(:settings) {{ "statement" => "SELECT * from test_table" }}
+    let(:events)   { [] }
+
+    before(:each) do
+      plugin.register
+    end
+
+    after(:each) do
+      plugin.stop
+    end
+
+    it "should transform all column string to UTF-8, default encoding" do
+      row = {"column0" => "foo", "column1" => "bar".force_encoding(Encoding::ISO_8859_1), "column2" => 3}
+      allow_any_instance_of(Sequel::JDBC::Derby::Dataset).to receive(:each).and_yield(row)
+      plugin.run(events)
+      ["column0", "column1"].each do |column_name|
+        expect(events[0][column_name].encoding).to eq(Encoding::UTF_8)
+      end
+    end
+
+    context "when using non default encoding as data charset" do
+
+      let(:settings) {{ "statement" => "SELECT * from test_table", "charset" => "US-ASCII" }}
+
+      it "should transform all column string to UTF-8 as final encoding" do
+        row = {"column0" => "foo", "column1" => "bar".force_encoding(Encoding::ISO_8859_1), "column2" => 3}
+        allow_any_instance_of(Sequel::JDBC::Derby::Dataset).to receive(:each).and_yield(row)
+        plugin.run(events)
+        ["column0", "column1"].each do |column_name|
+          expect(events[0][column_name].encoding).to eq(Encoding::UTF_8)
+        end
+      end
+
+    end
+
   end
 end


### PR DESCRIPTION
This PR adds the ability to have uniform encoding for strings read from the database as there are some situations where we might be fetching strings encoded in different formats.

There are situations where the JDBC driver interacting with databases that have globalization features could be fetching data encoded in different formats, for example some in `UTF-8` while others in `ASCII-8BIT`, so prevent this we introduced the usage of `LogStash::Util::Charset.new(@charset)` the same utility used for LS codecs to sort out encoding. With this addition all strings are going to be always in UTF-8 format.

In #143 were discussed some other alternative, for example providing some degree of granularity to let developers chose their encoding. This is a nice idea, but in this PR I propose for now a simpler and more uniform approach for all columns, reducing the config complexity and probable errors, if there is the need we can always introduce a more granular option.

Also keep in mind this is a bug that happen for LS versions that use the ruby event, not the javaone. 

In ruby event:  "String" {ASCII encode} ---> insert into event --> event --> retrieve from event --> "String" {ASCII encode}

In java event:  "String" {ASCII encode} ---> insert into event --> event --> retrieve from event --> "String" {UTF-8 encode}

what do you think?
