### PR TITLE
add encoding feature for string retrieved out of the jdbc stament

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
-## 4.0.2
-  - Added feature to read password from external file (#120).
+## 4.1.0
+  - Add an option to select the encoding data should be transform from,
+    this will make sure all strings read from the jdbc connector are
+    noremalized to be UTF-8 so no causing issues with later filters in LS.
 ## 4.0.1
   - Republish all the gems under jruby.
 ## 4.0.0
   - Update the plugin to the version 2.0 of the plugin api, this change is required for Logstash 5.0 compatibility. See https://github.com/elastic/logstash/issues/5141
+# 3.0.3
+  - Added feature to read password from external file (#120)
 # 3.0.2
   - Depend on logstash-core-plugin-api instead of logstash-core, removing the need to mass update plugins on major releases of logstash
 # 3.0.1

--- a/lib/logstash/inputs/jdbc.rb
+++ b/lib/logstash/inputs/jdbc.rb
@@ -261,7 +261,7 @@ class LogStash::Inputs::Jdbc < LogStash::Inputs::Base
 
   def should_convert(key, value)
     column_keys = @columns_to_encode.keys
-    value.is_a?(String) && (!@default_encoding.nil? || ( @default_encoding.nil? && column_keys.include?(key)) )
+    value.is_a?(String) && (!@default_encoding.nil? || column_keys.include?(key))
   end
 
   def find_converter_for(key, value)

--- a/lib/logstash/inputs/jdbc.rb
+++ b/lib/logstash/inputs/jdbc.rb
@@ -166,6 +166,18 @@ class LogStash::Inputs::Jdbc < LogStash::Inputs::Base
 
   # The character encoding for specific columns. This option will override the `:charset` option 
   # for the specified columns.
+  #
+  # Example:
+  # [source,ruby]
+  # ----------------------------------
+  # input {
+  #   jdbc {
+  #     ...
+  #     columns_charset => { "column0" => "ISO-8859-1" }
+  #     ...
+  #   }
+  # }
+  # this will only convert column0 that has ISO-8859-1 as an original encoding.
   config :columns_charset, :validate => :hash, :default => {}
 
   public

--- a/lib/logstash/inputs/jdbc.rb
+++ b/lib/logstash/inputs/jdbc.rb
@@ -212,7 +212,7 @@ class LogStash::Inputs::Jdbc < LogStash::Inputs::Base
 
     @jdbc_password = File.read(@jdbc_password_filepath).strip if @jdbc_password_filepath
 
-    if enable_encoding
+    if enable_encoding?
       @converters = {}
       @columns_charset.each do |column_name, encoding|
         @converters[encoding] = LogStash::Util::Charset.new(encoding)
@@ -248,7 +248,7 @@ class LogStash::Inputs::Jdbc < LogStash::Inputs::Base
     # update default parameters
     @parameters['sql_last_value'] = @sql_last_value
     execute_statement(@statement, @parameters) do |row|
-      if enable_encoding
+      if enable_encoding?
         ## do the necessary conversions to string elements
         row = Hash[row.map { |k, v| [k.to_s, convert(k, v)] }]
       end
@@ -266,7 +266,7 @@ class LogStash::Inputs::Jdbc < LogStash::Inputs::Base
 
   private
 
-  def enable_encoding
+  def enable_encoding?
     !@charset.nil? || !@columns_charset.empty?
   end
 

--- a/lib/logstash/inputs/jdbc.rb
+++ b/lib/logstash/inputs/jdbc.rb
@@ -160,14 +160,6 @@ class LogStash::Inputs::Jdbc < LogStash::Inputs::Base
   # Whether to force the lowercasing of identifier fields
   config :lowercase_column_names, :validate => :boolean, :default => true
 
-  # The character encoding used in this input. Examples include `UTF-8`
-  # and `cp1252`
-  #
-  # This setting is useful if some of your data is in `Latin-1` (aka `cp1252`)
-  # or in another character set other than `UTF-8`. After the conversion all data
-  # will be in `UTF-8` as the common encoding for LogStash pipeline.
-  config :charset, :validate => ::Encoding.name_list, :default => "UTF-8"
-
   public
 
   def register
@@ -200,7 +192,7 @@ class LogStash::Inputs::Jdbc < LogStash::Inputs::Base
 
     @jdbc_password = File.read(@jdbc_password_filepath).strip if @jdbc_password_filepath
 
-    @converter = LogStash::Util::Charset.new(@charset)
+    @converters = { Encoding::UTF_8 => LogStash::Util::Charset.new("UTF-8") }
   end # def register
 
   def run(queue)

--- a/lib/logstash/inputs/jdbc.rb
+++ b/lib/logstash/inputs/jdbc.rb
@@ -160,6 +160,14 @@ class LogStash::Inputs::Jdbc < LogStash::Inputs::Base
   # Whether to force the lowercasing of identifier fields
   config :lowercase_column_names, :validate => :boolean, :default => true
 
+  # The character encoding used in this input. Examples include `UTF-8`
+  # and `cp1252`
+  #
+  # This setting is useful if some of your data is in `Latin-1` (aka `cp1252`)
+  # or in another character set other than `UTF-8`. After the conversion all data
+  # will be in `UTF-8` as the common encoding for LogStash pipeline.
+  config :charset, :validate => ::Encoding.name_list, :default => "UTF-8"
+
   public
 
   def register
@@ -191,6 +199,8 @@ class LogStash::Inputs::Jdbc < LogStash::Inputs::Base
     end
 
     @jdbc_password = File.read(@jdbc_password_filepath).strip if @jdbc_password_filepath
+
+    @converter = LogStash::Util::Charset.new(@charset)
   end # def register
 
   def run(queue)

--- a/lib/logstash/plugin_mixins/jdbc.rb
+++ b/lib/logstash/plugin_mixins/jdbc.rb
@@ -258,12 +258,11 @@ module LogStash::PluginMixins::Jdbc
   private
   #Stringify row keys and decorate values when necessary
   def extract_values_from(row)
-    Hash[row.map { |k, v| [k.to_s, decorate_value(v)] }]
+    Hash[row.map { |k, v| [k.to_s, decorate_value(convert(v))] }]
   end
 
   private
   def decorate_value(value)
-
     if value.is_a?(Time)
       # transform it to LogStash::Timestamp as required by LS
       LogStash::Timestamp.new(value)
@@ -272,7 +271,13 @@ module LogStash::PluginMixins::Jdbc
       # This is slower, so we put it in as a conditional case.
       LogStash::Timestamp.new(Time.parse(value.to_s))
     else
-      value  # no-op
+      value
     end
+  end
+
+  private
+  # make sure the encoding is uniform over fields
+  def convert(value)
+    value.is_a?(String) ? @converter.convert(value) : value
   end
 end

--- a/lib/logstash/plugin_mixins/jdbc.rb
+++ b/lib/logstash/plugin_mixins/jdbc.rb
@@ -278,6 +278,15 @@ module LogStash::PluginMixins::Jdbc
   private
   # make sure the encoding is uniform over fields
   def convert(value)
-    value.is_a?(String) ? @converter.convert(value) : value
+    return value unless value.is_a?(String)
+    converter = find_converter_for value
+    converter.convert(value)
+  end
+
+  def find_converter_for(value)
+    unless @converters.keys.include?(value.encoding)
+      @converters[value.encoding] = LogStash::Util::Charset.new(value.encoding.to_s)
+    end
+    @converters[value.encoding]
   end
 end

--- a/lib/logstash/plugin_mixins/jdbc.rb
+++ b/lib/logstash/plugin_mixins/jdbc.rb
@@ -258,7 +258,7 @@ module LogStash::PluginMixins::Jdbc
   private
   #Stringify row keys and decorate values when necessary
   def extract_values_from(row)
-    Hash[row.map { |k, v| [k.to_s, decorate_value(convert(v))] }]
+    Hash[row.map { |k, v| [k.to_s, decorate_value(v)] }]
   end
 
   private
@@ -273,20 +273,5 @@ module LogStash::PluginMixins::Jdbc
     else
       value
     end
-  end
-
-  private
-  # make sure the encoding is uniform over fields
-  def convert(value)
-    return value unless value.is_a?(String)
-    converter = find_converter_for value
-    converter.convert(value)
-  end
-
-  def find_converter_for(value)
-    unless @converters.keys.include?(value.encoding)
-      @converters[value.encoding] = LogStash::Util::Charset.new(value.encoding.to_s)
-    end
-    @converters[value.encoding]
   end
 end

--- a/logstash-input-jdbc.gemspec
+++ b/logstash-input-jdbc.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-input-jdbc'
-  s.version         = '4.0.2'
+  s.version         = '4.1.0'
   s.licenses = ['Apache License (2.0)']
   s.summary = "This example input streams a string at a definable interval."
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/inputs/jdbc_spec.rb
+++ b/spec/inputs/jdbc_spec.rb
@@ -902,7 +902,9 @@ describe LogStash::Inputs::Jdbc do
     let(:settings) {{ "statement" => "SELECT * from test_table" }}
     let(:events)   { [] }
     let(:row) do
-      {"column0" => "foo", "column1" => "bar".force_encoding(Encoding::ISO_8859_1), "column2" => 3}
+      {"column0" => "foo",
+       "column1" => "bar".force_encoding(Encoding::ISO_8859_1),
+       "column2" => 3}
     end
 
     before(:each) do
@@ -915,7 +917,9 @@ describe LogStash::Inputs::Jdbc do
     end
 
     it "should not convert any column by default" do
-      encoded_row = { "column0" => "foo", "column1" => "bar".force_encoding(Encoding::ISO_8859_1), "column2" => 3 }
+      encoded_row = { "column0" => "foo", 
+                      "column1" => "bar".force_encoding(Encoding::ISO_8859_1), 
+                      "column2" => 3 }
       expect(LogStash::Event).to receive(:new) do |row|
         row.each do |k, v|
           next unless v.is_a?(String)
@@ -933,7 +937,9 @@ describe LogStash::Inputs::Jdbc do
       end
 
       let(:row) do
-        {"column0" => "foo".force_encoding(Encoding::ISO_8859_1), "column1" => "bar".force_encoding(Encoding::ISO_8859_1), "column2" => 3}
+        {"column0" => "foo".force_encoding(Encoding::ISO_8859_1), 
+         "column1" => "bar".force_encoding(Encoding::ISO_8859_1),
+         "column2" => 3}
       end
 
       it "should transform all column string to UTF-8, default encoding" do
@@ -956,12 +962,18 @@ describe LogStash::Inputs::Jdbc do
       end
 
       let(:row) do
-        {"column0" => "foo", "column1" => "bar".force_encoding(Encoding::ISO_8859_1), "column2" => 3, "column3" => "berlin".force_encoding(Encoding::ASCII_8BIT)}
+        {"column0" => "foo", 
+         "column1" => "bar".force_encoding(Encoding::ISO_8859_1), 
+         "column2" => 3, 
+         "column3" => "berlin".force_encoding(Encoding::ASCII_8BIT)}
       end
 
       it "should only convert the selected column" do
         encoded_row = {
-          "column0" => "foo", "column1" => "bar", "column2" => 3, "column3" => "berlin".force_encoding(Encoding::ASCII_8BIT)
+          "column0" => "foo",
+          "column1" => "bar",
+          "column2" => 3, 
+          "column3" => "berlin".force_encoding(Encoding::ASCII_8BIT)
         }
         expect(LogStash::Event).to receive(:new) do |row|
           row.each do |k, v|

--- a/spec/inputs/jdbc_spec.rb
+++ b/spec/inputs/jdbc_spec.rb
@@ -914,7 +914,7 @@ describe LogStash::Inputs::Jdbc do
       plugin.stop
     end
 
-    it "shuold not convert any column by default" do
+    it "should not convert any column by default" do
       encoded_row = { "column0" => "foo", "column1" => "bar".force_encoding(Encoding::ISO_8859_1), "column2" => 3 }
       expect(LogStash::Event).to receive(:new) do |row|
         row.each do |k, v|

--- a/spec/inputs/jdbc_spec.rb
+++ b/spec/inputs/jdbc_spec.rb
@@ -927,7 +927,11 @@ describe LogStash::Inputs::Jdbc do
 
     context "when all string columns should be encoded" do
 
-      let(:settings) {{ "statement" => "SELECT * from test_table", "enable_encoding" => true }}
+      let(:settings) {{ "statement" => "SELECT * from test_table", "columns_to_encode" => { "_" => "ISO-8859-1" } }}
+
+      let(:row) do
+        {"column0" => "foo".force_encoding(Encoding::ISO_8859_1), "column1" => "bar".force_encoding(Encoding::ISO_8859_1), "column2" => 3}
+      end
 
       it "should transform all column string to UTF-8, default encoding" do
         encoded_row = { "column0" => "foo", "column1" => "bar", "column2" => 3 }
@@ -948,7 +952,10 @@ describe LogStash::Inputs::Jdbc do
 
     context "when only an specific column should be converted" do
 
-      let(:settings) {{ "statement" => "SELECT * from test_table", "enable_encoding" => true, "columns_to_encode" => [ "column1" ] }}
+      let(:settings) do
+        { "statement" => "SELECT * from test_table",
+          "columns_to_encode" => { "column1" => "ISO-8859-1" } }
+      end
 
       let(:row) do
         {"column0" => "foo", "column1" => "bar".force_encoding(Encoding::ISO_8859_1), "column2" => 3, "column3" => "berlin".force_encoding(Encoding::ASCII_8BIT)}

--- a/spec/inputs/jdbc_spec.rb
+++ b/spec/inputs/jdbc_spec.rb
@@ -929,7 +929,7 @@ describe LogStash::Inputs::Jdbc do
 
       let(:settings) do
         { "statement" => "SELECT * from test_table",
-          "default_encoding" => "ISO-8859-1" }
+          "charset" => "ISO-8859-1" }
       end
 
       let(:row) do
@@ -957,7 +957,7 @@ describe LogStash::Inputs::Jdbc do
 
       let(:settings) do
         { "statement" => "SELECT * from test_table",
-          "columns_to_encode" => { "column1" => "ISO-8859-1" } }
+          "columns_charset" => { "column1" => "ISO-8859-1" } }
       end
 
       let(:row) do

--- a/spec/inputs/jdbc_spec.rb
+++ b/spec/inputs/jdbc_spec.rb
@@ -927,7 +927,10 @@ describe LogStash::Inputs::Jdbc do
 
     context "when all string columns should be encoded" do
 
-      let(:settings) {{ "statement" => "SELECT * from test_table", "columns_to_encode" => { "_" => "ISO-8859-1" } }}
+      let(:settings) do
+        { "statement" => "SELECT * from test_table",
+          "default_encoding" => "ISO-8859-1" }
+      end
 
       let(:row) do
         {"column0" => "foo".force_encoding(Encoding::ISO_8859_1), "column1" => "bar".force_encoding(Encoding::ISO_8859_1), "column2" => 3}

--- a/spec/inputs/jdbc_spec.rb
+++ b/spec/inputs/jdbc_spec.rb
@@ -946,11 +946,6 @@ describe LogStash::Inputs::Jdbc do
         end
         plugin.run(events)
       end
-
-      it "should create special converters for each string time found in the row" do
-        expect(LogStash::Util::Charset).to receive(:new).with("ISO-8859-1").and_call_original
-        plugin.run(events)
-      end
     end
 
     context "when only an specific column should be converted" do

--- a/spec/inputs/jdbc_spec.rb
+++ b/spec/inputs/jdbc_spec.rb
@@ -920,7 +920,7 @@ describe LogStash::Inputs::Jdbc do
 
     context "when using non default encoding as data charset" do
 
-      let(:settings) {{ "statement" => "SELECT * from test_table", "charset" => "US-ASCII" }}
+      let(:settings) {{ "statement" => "SELECT * from test_table" }}
 
       it "should transform all column string to UTF-8 as final encoding" do
         row = {"column0" => "foo", "column1" => "bar".force_encoding(Encoding::ISO_8859_1), "column2" => 3}

--- a/spec/inputs/jdbc_spec.rb
+++ b/spec/inputs/jdbc_spec.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require "logstash/devutils/rspec/spec_helper"
 require "logstash/inputs/jdbc"
 require "jdbc/derby"
@@ -918,19 +919,13 @@ describe LogStash::Inputs::Jdbc do
       end
     end
 
-    context "when using non default encoding as data charset" do
 
-      let(:settings) {{ "statement" => "SELECT * from test_table" }}
-
-      it "should transform all column string to UTF-8 as final encoding" do
-        row = {"column0" => "foo", "column1" => "bar".force_encoding(Encoding::ISO_8859_1), "column2" => 3}
-        allow_any_instance_of(Sequel::JDBC::Derby::Dataset).to receive(:each).and_yield(row)
-        plugin.run(events)
-        ["column0", "column1"].each do |column_name|
-          expect(events[0].get(column_name).encoding).to eq(Encoding::UTF_8)
-        end
-      end
-
+    it "should create special converters for each string time found in the row" do
+      row = {"column0" => "foo", "column1" => "bar".force_encoding(Encoding::ISO_8859_1), "column2" => 3}
+      allow_any_instance_of(Sequel::JDBC::Derby::Dataset).to receive(:each).and_yield(row)
+      expect(LogStash::Util::Charset).to receive(:new).with("ISO-8859-1").and_call_original
+      plugin.run(events)
     end
+
   end
 end


### PR DESCRIPTION
This PR adds the ability to have uniform encoding for strings read from the database as there are some situations where we might be fetching strings encoded in different formats.

There are situations where the JDBC driver interacting with databases that have globalization features could be fetching data encoded in different formats, for example some in UTF-8 while others in ASCII-8BIT, so prevent this we introduced the usage of LogStash::Util::Charset.new(@charset) the same utility used for LS codecs to sort out encoding. With this addition all strings are going to be always in UTF-8 format.

In #143 were discussed some other alternative, for example providing some degree of granularity to let developers chose their encoding. This is a nice idea, but in this PR I propose for now a simpler and more uniform approach for all columns, reducing the config complexity and probable errors, if there is the need we can always introduce a more granular option.

TODO:

* [x] include config to avoid any conversion at all.
* [x] include config option to select only a list of columns to convert.

In resume for this PR, I propose to have:

* An entry point config variable, `enable_encoding` (false by default) that enable the character conversions.
* An array where we can specify a list of columns we want to convert. If some are specified only this will be converted, if empty (default value) all will be converted.

The encoding is selected based on the incoming string encoding to reduce errors when selecting the wrong encoding, or the encoding changes without noticing for the operators. It also helps keeping the config options smaller.

what do you think?