### PR TITLE
Add metrics to the jdbc input operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.2.0 
+  - Add  metrics support for events, operations, connections and errors produced during execution (based on exception being raised).
+
 ## 4.1.1
   - Relax constraint on logstash-core-plugin-api to >= 1.60 <= 2.99
 

--- a/lib/logstash/plugin_mixins/jdbc.rb
+++ b/lib/logstash/plugin_mixins/jdbc.rb
@@ -116,7 +116,7 @@ module LogStash::PluginMixins::Jdbc
           raise e
         else
           @logger.error("Failed to connect to database. #{@jdbc_pool_timeout} second timeout exceeded. Trying again.")
-          @metric_errors.increment(:connection_retry)
+          @metric_errors.increment(:connection_retries)
         end
       rescue Sequel::Error => e
         if retry_attempts <= 0
@@ -124,7 +124,7 @@ module LogStash::PluginMixins::Jdbc
           raise e
         else
           @logger.error("Unable to connect to database. Trying again", :error_message => e.message)
-          @metric_errors.increment(:connection_retry)
+          @metric_errors.increment(:connection_retries)
         end
       end
       sleep(@connection_retry_attempts_wait_time)
@@ -161,7 +161,7 @@ module LogStash::PluginMixins::Jdbc
       raise LogStash::ConfigurationError, "#{e}. #{message}"
     end
     @database = jdbc_connect()
-    metric.increment(:connection)
+    metric.increment(:connections)
 
     @database.extension(:pagination)
     if @jdbc_default_timezone

--- a/lib/logstash/plugin_mixins/jdbc.rb
+++ b/lib/logstash/plugin_mixins/jdbc.rb
@@ -209,7 +209,7 @@ module LogStash::PluginMixins::Jdbc
 
       @tracking_column_warning_sent = false
       @logger.debug? and @logger.debug("Executing JDBC query", :statement => statement, :parameters => parameters, :count => query.count)
-      metric.gauge(:query_count, query.count)
+      metric.gauge(:rows_in, query.count)
 
       if @jdbc_paging_enabled
         query.each_page(@jdbc_page_size) do |paged_dataset|

--- a/logstash-input-jdbc.gemspec
+++ b/logstash-input-jdbc.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-input-jdbc'
-  s.version         = '4.1.1'
+  s.version         = '4.2.0'
   s.licenses = ['Apache License (2.0)']
   s.summary = "This example input streams a string at a definable interval."
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/inputs/jdbc_spec.rb
+++ b/spec/inputs/jdbc_spec.rb
@@ -837,7 +837,7 @@ describe LogStash::Inputs::Jdbc do
     let(:logger) { double("logger") }
 
     it "should report the staments to logging" do
-      expect(logger).to receive(:debug).with(kind_of(String)).once
+      expect(logger).to receive(:debug).with(kind_of(String)).twice
       plugin.run(queue)
     end
   end


### PR DESCRIPTION
Add metrics to track:
- # events processed.
- # connections open.
- # operations performed with the database
- # errors that happened during execution.
- small others last sql_value, query size, etc (useful to debug behaviour).

related to https://github.com/elastic/logstash/issues/5607 https://github.com/elastic/logstash/issues/5717
