### PR TITLE
Add bool config for tracking column as timestamp

### DIFF
--- a/lib/logstash/inputs/jdbc.rb
+++ b/lib/logstash/inputs/jdbc.rb
@@ -151,8 +151,8 @@ class LogStash::Inputs::Jdbc < LogStash::Inputs::Base
   # If tracking column value rather than timestamp, the column whose value is to be tracked
   config :tracking_column, :validate => :string
 
-  # Tracking column is a timestamp value to be tracked, rather than an int
-  config :tracking_column_is_timestamp, :validate => :boolean, :default => false
+  # Type of tracking column. Currently only "numeric" and "timestamp"
+  config :tracking_column_type, :validate => ['numeric', 'timestamp'], :default => 'numeric'
 
   # Whether the previous run state should be preserved
   config :clean_run, :validate => :boolean, :default => false

--- a/lib/logstash/inputs/jdbc.rb
+++ b/lib/logstash/inputs/jdbc.rb
@@ -151,6 +151,9 @@ class LogStash::Inputs::Jdbc < LogStash::Inputs::Base
   # If tracking column value rather than timestamp, the column whose value is to be tracked
   config :tracking_column, :validate => :string
 
+  # Tracking column is a timestamp value to be tracked, rather than an int
+  config :tracking_column_is_timestamp, :validate => :boolean, :default => false
+
   # Whether the previous run state should be preserved
   config :clean_run, :validate => :boolean, :default => false
 

--- a/lib/logstash/plugin_mixins/jdbc.rb
+++ b/lib/logstash/plugin_mixins/jdbc.rb
@@ -213,12 +213,18 @@ module LogStash::PluginMixins::Jdbc
         query.each_page(@jdbc_page_size) do |paged_dataset|
           paged_dataset.each do |row|
             sql_last_value = get_column_value(row) if @use_column_value
+            if @tracking_column_type=="timestamp" and @use_column_value and sql_last_value.is_a?(DateTime)
+              sql_last_value=Time.parse(sql_last_value.to_s) # Coerce the timestamp to a `Time`
+            end
             yield extract_values_from(row)
           end
         end
       else
         query.each do |row|
           sql_last_value = get_column_value(row) if @use_column_value
+          if @tracking_column_type=="timestamp" and @use_column_value and sql_last_value.is_a?(DateTime)
+            sql_last_value=Time.parse(sql_last_value.to_s) # Coerce the timestamp to a `Time`
+          end
           yield extract_values_from(row)
         end
       end

--- a/lib/logstash/plugin_mixins/jdbc.rb
+++ b/lib/logstash/plugin_mixins/jdbc.rb
@@ -182,8 +182,13 @@ module LogStash::PluginMixins::Jdbc
     else
       @database.identifier_output_method = :to_s
     end
-    if @use_column_value and not @tracking_column_is_timestamp
-      @sql_last_value = 0
+    if @use_column_value
+      case @tracking_column_type
+        when "numeric"
+          @sql_last_value = 0
+        when "timestamp"
+          @sql_last_value = Time.at(0).utc
+      end
     else
       @sql_last_value = Time.at(0).utc
     end

--- a/lib/logstash/plugin_mixins/jdbc.rb
+++ b/lib/logstash/plugin_mixins/jdbc.rb
@@ -182,7 +182,7 @@ module LogStash::PluginMixins::Jdbc
     else
       @database.identifier_output_method = :to_s
     end
-    if @use_column_value
+    if @use_column_value and not @tracking_column_is_timestamp
       @sql_last_value = 0
     else
       @sql_last_value = Time.at(0).utc

--- a/spec/inputs/jdbc_spec.rb
+++ b/spec/inputs/jdbc_spec.rb
@@ -497,6 +497,7 @@ describe LogStash::Inputs::Jdbc do
       test_table.insert(:num => nums[0], :created_at => Time.now.utc, :custom_time => times[0])
       test_table.insert(:num => nums[1], :created_at => Time.now.utc, :custom_time => times[1])
       plugin.run(queue)
+      expect(plugin.instance_variable_get("@sql_last_value").class).to eq(Time.parse(times[0]).class)
       expect(plugin.instance_variable_get("@sql_last_value")).to eq(Time.parse(times[1]))
       test_table.insert(:num => nums[2], :created_at => Time.now.utc, :custom_time => times[2])
       test_table.insert(:num => nums[3], :created_at => Time.now.utc, :custom_time => times[3])

--- a/spec/inputs/jdbc_spec.rb
+++ b/spec/inputs/jdbc_spec.rb
@@ -463,6 +463,49 @@ describe LogStash::Inputs::Jdbc do
     end
   end
 
+  context "when iteratively running plugin#run with timestamp tracking column with column value" do
+    let(:mixin_settings) do
+      { "jdbc_user" => ENV['USER'], "jdbc_driver_class" => "org.apache.derby.jdbc.EmbeddedDriver",
+        "jdbc_connection_string" => "jdbc:derby:memory:testdb;create=true"
+      }
+    end
+
+    let(:settings) do
+      { "statement" => "SELECT num, created_at, custom_time FROM test_table WHERE custom_time > :sql_last_value",
+        "use_column_value" => true,
+        "tracking_column" => "custom_time",
+        "tracking_column_is_timestamp" => true,
+        "last_run_metadata_path" => Stud::Temporary.pathname }
+    end
+
+    let(:nums) { [10, 20, 30, 40, 50] }
+    let(:times) {["2015-05-06 13:14:15","2015-05-07 13:14:15","2015-05-08 13:14:15","2015-05-09 13:14:15","2015-05-10 13:14:15"]}
+
+    before do
+      plugin.register
+    end
+
+    after do
+      plugin.stop
+    end
+
+    it "should successfully update sql_last_value" do
+      test_table = db[:test_table]
+
+      plugin.run(queue)
+      expect(plugin.instance_variable_get("@sql_last_value")).to eq(Time.parse("1970-01-01 00:00:00.000000000 +0000"))
+      test_table.insert(:num => nums[0], :created_at => Time.now.utc, :custom_time => times[0])
+      test_table.insert(:num => nums[1], :created_at => Time.now.utc, :custom_time => times[1])
+      plugin.run(queue)
+      expect(plugin.instance_variable_get("@sql_last_value")).to eq(Time.parse(times[1]))
+      test_table.insert(:num => nums[2], :created_at => Time.now.utc, :custom_time => times[2])
+      test_table.insert(:num => nums[3], :created_at => Time.now.utc, :custom_time => times[3])
+      test_table.insert(:num => nums[4], :created_at => Time.now.utc, :custom_time => times[4])
+      plugin.run(queue)
+      expect(plugin.instance_variable_get("@sql_last_value")).to eq(Time.parse(times[4]))
+    end
+  end
+
   context "when iteratively running plugin#run with tracking_column and stored metadata" do
     let(:mixin_settings) do
       { "jdbc_user" => ENV['USER'], "jdbc_driver_class" => "org.apache.derby.jdbc.EmbeddedDriver",

--- a/spec/inputs/jdbc_spec.rb
+++ b/spec/inputs/jdbc_spec.rb
@@ -474,7 +474,7 @@ describe LogStash::Inputs::Jdbc do
       { "statement" => "SELECT num, created_at, custom_time FROM test_table WHERE custom_time > :sql_last_value",
         "use_column_value" => true,
         "tracking_column" => "custom_time",
-        "tracking_column_is_timestamp" => true,
+        "tracking_column_type" => "timestamp",
         "last_run_metadata_path" => Stud::Temporary.pathname }
     end
 


### PR DESCRIPTION
Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/

This allows plugin users to set `use_column_value` on tracking columns
where the column type is a timestamp. Currently, this is only possible
using a numeric column, but there are use cases where the user wants to
select rows from a table where the column value is greater than the last
seen timestamp value of that column.

It turns out that this behaviour works fine with simply setting
`use_column_value` to true on the required column. The only change
needed is to add a flag indicating that on a clean run, the default min
value should be set to `Time.at(0).utc` rather than `0`.

This should close logstash-plugins/logstash-input-jdbc#125