### PR TITLE
fix to be compatible with LS 5.0 core

### DIFF
--- a/lib/logstash/inputs/jdbc.rb
+++ b/lib/logstash/inputs/jdbc.rb
@@ -186,6 +186,7 @@ class LogStash::Inputs::Jdbc < LogStash::Inputs::Base
   public
 
   def register
+    @logger = self.logger
     require "rufus/scheduler"
     prepare_jdbc_connection
 

--- a/lib/logstash/plugin_mixins/jdbc.rb
+++ b/lib/logstash/plugin_mixins/jdbc.rb
@@ -8,8 +8,6 @@ require "date"
 # for potential reuse in other plugins (input/output)
 module LogStash::PluginMixins::Jdbc
 
-  @logger = Cabin::Channel.get(LogStash)
-
   # This method is called when someone includes this module
   def self.included(base)
     # Add these methods to the 'base' given.

--- a/spec/inputs/jdbc_spec.rb
+++ b/spec/inputs/jdbc_spec.rb
@@ -865,8 +865,7 @@ describe LogStash::Inputs::Jdbc do
     let(:num_rows) { 5 }
 
     before do
-      plugin.instance_variable_set("@logger", logger)
-      allow(logger).to receive(:debug?)
+      allow(plugin.logger).to receive(:debug?)
       num_rows.times do
         db[:test_table].insert(:num => 1)
       end
@@ -878,10 +877,8 @@ describe LogStash::Inputs::Jdbc do
       plugin.stop
     end
 
-    let(:logger) { double("logger") }
-
-    it "should report the staments to logging" do
-      expect(logger).to receive(:debug).with(kind_of(String)).once
+    it "should report the statements to logging" do
+      expect(plugin.logger).to receive(:debug).once
       plugin.run(queue)
     end
   end


### PR DESCRIPTION
LS 5.0 introduces log4j2 logging, so this PR updates the plugin to support that.