### PR TITLE
Added section about using multiple SQL statements

### DIFF
--- a/lib/logstash/inputs/jdbc.rb
+++ b/lib/logstash/inputs/jdbc.rb
@@ -84,6 +84,21 @@ require "yaml" # persistence
 # The file option only supports one SQL statement. The plugin will only accept one of the options.
 # It cannot read a statement from a file as well as from the `statement` configuration parameter.
 #
+# ==== Configuring multiple SQL statements 
+#
+# Configuring multiple SQL statements is useful when there is a need to query and ingest data 
+# from different database tables or views. It is possible to define separate Logstash 
+# configuration files for each statement or to define multiple statements in a single configuration 
+# file. When using multiple statements in a single Logstash configuration file, each statement 
+# has to be defined as a separate jdbc input (including jdbc driver, connection string and other 
+# required parameters). 
+#
+# Please note that if any of the statements use the `sql_last_value` parameter (e.g. for 
+# ingesting only data changed since last run), each input should define its own 
+# `last_run_metadata_path` parameter. Failure to do so will result in undesired behaviour, as
+# all inputs will store their state to the same (default) metadata file, effectively 
+# overwriting each other's `sql_last_value`.
+#
 # ==== Predefined Parameters
 #
 # Some parameters are built-in and can be used from within your queries.


### PR DESCRIPTION
As discussed in https://discuss.elastic.co/t/sql-last-value-doesnt-reiterate-with-multiple-jdbc-inputs/63523, this PR represents a doc update to include some guidance on using multiple SQL statements and the importance of last_run_metadata_path parameter when multiple statements also use the sql_last_value parameter for storing state.