### PR TITLE
Corrected the meaning of the statement.

### DIFF
--- a/lib/logstash/inputs/jdbc.rb
+++ b/lib/logstash/inputs/jdbc.rb
@@ -4,7 +4,7 @@ require "logstash/namespace"
 require "logstash/plugin_mixins/jdbc"
 require "yaml" # persistence
 
-# This plugin was created as a way to ingest data in any database
+# This plugin was created as a way to ingest data from any database
 # with a JDBC interface into Logstash. You can periodically schedule ingestion
 # using a cron syntax (see `schedule` setting) or run the query one time to load
 # data into Logstash. Each row in the resultset becomes a single event.


### PR DESCRIPTION
According to my understanding what the logstash-input-jdbc plugin do is, get the data from the relational database into the logsash, hence the change.