### PR TITLE
tracking_column_type => string

### DIFF
--- a/lib/logstash/inputs/jdbc.rb
+++ b/lib/logstash/inputs/jdbc.rb
@@ -84,19 +84,19 @@ require "yaml" # persistence
 # The file option only supports one SQL statement. The plugin will only accept one of the options.
 # It cannot read a statement from a file as well as from the `statement` configuration parameter.
 #
-# ==== Configuring multiple SQL statements 
+# ==== Configuring multiple SQL statements
 #
-# Configuring multiple SQL statements is useful when there is a need to query and ingest data 
-# from different database tables or views. It is possible to define separate Logstash 
-# configuration files for each statement or to define multiple statements in a single configuration 
-# file. When using multiple statements in a single Logstash configuration file, each statement 
-# has to be defined as a separate jdbc input (including jdbc driver, connection string and other 
-# required parameters). 
+# Configuring multiple SQL statements is useful when there is a need to query and ingest data
+# from different database tables or views. It is possible to define separate Logstash
+# configuration files for each statement or to define multiple statements in a single configuration
+# file. When using multiple statements in a single Logstash configuration file, each statement
+# has to be defined as a separate jdbc input (including jdbc driver, connection string and other
+# required parameters).
 #
-# Please note that if any of the statements use the `sql_last_value` parameter (e.g. for 
-# ingesting only data changed since last run), each input should define its own 
+# Please note that if any of the statements use the `sql_last_value` parameter (e.g. for
+# ingesting only data changed since last run), each input should define its own
 # `last_run_metadata_path` parameter. Failure to do so will result in undesired behaviour, as
-# all inputs will store their state to the same (default) metadata file, effectively 
+# all inputs will store their state to the same (default) metadata file, effectively
 # overwriting each other's `sql_last_value`.
 #
 # ==== Predefined Parameters
@@ -166,8 +166,8 @@ class LogStash::Inputs::Jdbc < LogStash::Inputs::Base
   # If tracking column value rather than timestamp, the column whose value is to be tracked
   config :tracking_column, :validate => :string
 
-  # Type of tracking column. Currently only "numeric" and "timestamp"
-  config :tracking_column_type, :validate => ['numeric', 'timestamp'], :default => 'numeric'
+  # Type of tracking column.
+  config :tracking_column_type, :validate => ['numeric', 'timestamp', 'string'], :default => 'numeric'
 
   # Whether the previous run state should be preserved
   config :clean_run, :validate => :boolean, :default => false
@@ -178,11 +178,11 @@ class LogStash::Inputs::Jdbc < LogStash::Inputs::Base
   # Whether to force the lowercasing of identifier fields
   config :lowercase_column_names, :validate => :boolean, :default => true
 
-  # The character encoding of all columns, leave empty if the columns are already properly UTF-8 
+  # The character encoding of all columns, leave empty if the columns are already properly UTF-8
   # encoded. Specific columns charsets using :columns_charset can override this setting.
   config :charset, :validate => :string
 
-  # The character encoding for specific columns. This option will override the `:charset` option 
+  # The character encoding for specific columns. This option will override the `:charset` option
   # for the specified columns.
   #
   # Example:

--- a/lib/logstash/plugin_mixins/jdbc.rb
+++ b/lib/logstash/plugin_mixins/jdbc.rb
@@ -113,7 +113,7 @@ module LogStash::PluginMixins::Jdbc
           @logger.error("Failed to connect to database. #{@jdbc_pool_timeout} second timeout exceeded. Tried #{@connection_retry_attempts} times.")
           raise e
         else
-          @logger.error("Failed to connect to database. #{@jdbc_pool_timeout} second timeout exceeded. Trying again.")  
+          @logger.error("Failed to connect to database. #{@jdbc_pool_timeout} second timeout exceeded. Trying again.")
         end
       rescue Sequel::Error => e
         if retry_attempts <= 0
@@ -186,6 +186,8 @@ module LogStash::PluginMixins::Jdbc
           @sql_last_value = 0
         when "timestamp"
           @sql_last_value = Time.at(0).utc
+        when "string"
+          @sql_last_value = ""
       end
     else
       @sql_last_value = Time.at(0).utc


### PR DESCRIPTION
We needed to use our primary key as the `sql_last_value`. Our primary key is a string with sequential integers prefixed with letters. 

Added type `string` to `tracking_column_type` to use this primary key as our `sql_last_value` with a default value of `""`. 

In the input configuration, users can specify `tracking_column_type` and use a `tracking_column` that uses type `string`
```
jdbc {
  tracking_column_type => "string"      
  tracking_column => "string_column"  
}
```
