### PR TITLE
Fix jdbc_fetch_size usage with postgresql (#103)

### DIFF
--- a/lib/logstash/plugin_mixins/jdbc.rb
+++ b/lib/logstash/plugin_mixins/jdbc.rb
@@ -205,7 +205,7 @@ module LogStash::PluginMixins::Jdbc
       query = @database[statement, parameters]
       sql_last_value = @use_column_value ? @sql_last_value : Time.now.utc
       @tracking_column_warning_sent = false
-      @logger.debug? and @logger.debug("Executing JDBC query", :statement => statement, :parameters => parameters, :count => query.count)
+      @logger.debug? and @logger.debug("Executing JDBC query", :statement => statement, :parameters => parameters)
 
       if @jdbc_paging_enabled
         query.each_page(@jdbc_page_size) do |paged_dataset|

--- a/lib/logstash/plugin_mixins/jdbc.rb
+++ b/lib/logstash/plugin_mixins/jdbc.rb
@@ -209,6 +209,8 @@ module LogStash::PluginMixins::Jdbc
       @tracking_column_warning_sent = false
       @logger.debug? and @logger.debug("Executing JDBC query", :statement => statement, :parameters => parameters)
 
+      # Execute query in transaction cause PG driver require autocommit off for set fetch count
+      # See: https://jdbc.postgresql.org/documentation/head/query.html
       @database.transaction do
         if @jdbc_paging_enabled
           query.each_page(@jdbc_page_size) do |paged_dataset|

--- a/spec/inputs/jdbc_spec.rb
+++ b/spec/inputs/jdbc_spec.rb
@@ -833,7 +833,7 @@ describe LogStash::Inputs::Jdbc do
       {
         "statement" => "SELECT * FROM test_table",
         "jdbc_pool_timeout" => 0,
-        "jdbc_connection_string" => 'mock://localhost:1527/db',
+        "jdbc_connection_string" => 'jdbc:derby:memory:testdb;create=true',
         "sequel_opts" => {
           "max_connections" => 1
         }

--- a/spec/inputs/jdbc_spec.rb
+++ b/spec/inputs/jdbc_spec.rb
@@ -880,7 +880,7 @@ describe LogStash::Inputs::Jdbc do
     end
 
     it "should report the statements to logging" do
-      expect(plugin.logger).to receive(:debug).once
+      expect(plugin.logger).to receive(:debug).thrice
       plugin.run(queue)
     end
   end


### PR DESCRIPTION
According to documentation (https://jdbc.postgresql.org/documentation/head/query.html) we need to autocommit off if setFetchSize is used. So i wrap statement execution in transaction with Sequel::JDBC::Transaction cls and rollback transaction after all.