### PR TITLE
Cleanup test issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 4.2.0
+ - Automatically reconnect on connection issues
+ - Fix test failures
+ - Explicitly load identifier mangling from Sequel to prevent
+   warning logs
+
 ## 4.1.3
  - Fix part1 of #172, coerce SQL DATE to LS Timestamp
 

--- a/lib/logstash/plugin_mixins/jdbc.rb
+++ b/lib/logstash/plugin_mixins/jdbc.rb
@@ -179,6 +179,9 @@ module LogStash::PluginMixins::Jdbc
 
     @database.sql_log_level = @sql_log_level.to_sym
     @database.logger = @logger
+
+    @database.extension :identifier_mangling
+
     if @lowercase_column_names
       @database.identifier_output_method = :downcase
     else

--- a/logstash-input-jdbc.gemspec
+++ b/logstash-input-jdbc.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-input-jdbc'
-  s.version         = '4.1.3'
+  s.version         = '4.2.0'
   s.licenses = ['Apache License (2.0)']
   s.summary = "This example input streams a string at a definable interval."
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/inputs/jdbc_spec.rb
+++ b/spec/inputs/jdbc_spec.rb
@@ -916,7 +916,7 @@ describe LogStash::Inputs::Jdbc do
       it "the field names are lower case" do
         plugin.run(events)
         expect(events.first.to_hash.keys.sort).to eq(
-          ["@timestamp", "@version","num", "somestring", "tags"])
+          ["@timestamp", "@version","num", "somestring"])
       end
     end
 
@@ -925,7 +925,7 @@ describe LogStash::Inputs::Jdbc do
       it "the field names are UPPER case (natural for Derby DB)" do
         plugin.run(events)
         expect(events.first.to_hash.keys.sort).to eq(
-          ["@timestamp", "@version","NUM", "SOMESTRING", "tags"])
+          ["@timestamp", "@version","NUM", "SOMESTRING"])
       end
     end
   end


### PR DESCRIPTION
This fixes some test failures introduced when merging #185 . These failures weren't the fault of the PR, but rather due to a change in LS core where 'tags' was being incorrectly included in the `to_hash` method. Now that it's fixed in core the tests in this plugin were failing again.

This also explicitly imports the Sequel mangling extension. Failing to do so results in deprecation warnings. This feature is not deprecated, but its automatic importation is.