### PR TITLE
Fix broken jdbc_pass_word_filepath

### DIFF
--- a/lib/logstash/inputs/jdbc.rb
+++ b/lib/logstash/inputs/jdbc.rb
@@ -232,7 +232,7 @@ class LogStash::Inputs::Jdbc < LogStash::Inputs::Base
       raise(LogStash::ConfigurationError, "Only one of :jdbc_password, :jdbc_password_filepath may be set at a time.")
     end
 
-    @jdbc_password = File.read(@jdbc_password_filepath).strip if @jdbc_password_filepath
+    @jdbc_password = LogStash::Util::Password.new(File.read(@jdbc_password_filepath).strip) if @jdbc_password_filepath
 
     if enable_encoding?
       @converters = {}

--- a/spec/inputs/jdbc_spec.rb
+++ b/spec/inputs/jdbc_spec.rb
@@ -117,7 +117,7 @@ describe LogStash::Inputs::Jdbc do
     end
 
     it "should read in jdbc_password from file" do
-      expect(plugin.jdbc_password).to eq(jdbc_password)
+      expect(plugin.jdbc_password.value).to eq(jdbc_password)
     end
   end
 


### PR DESCRIPTION
This fixes the type mismatch error on `@jdbc_password` caused by the` jdbc_password_filepath` feature.
`@jdbc_password` should be of type `LogStash::Util::Password` instead of `string`.

Now the jdbc_password_filepath feature should work as intended.