### PR TITLE
Mark database connection as dead even when disconnecting fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.2.4
+  - [#220](https://github.com/logstash-plugins/logstash-input-jdbc/issues/220) Log exception when database connection test fails
+  - Database reconnect: Mark old connection as dead even when clean disconnect fails.
+
 ## 4.2.3
   - Fix some documentation issues
 

--- a/lib/logstash/plugin_mixins/jdbc.rb
+++ b/lib/logstash/plugin_mixins/jdbc.rb
@@ -170,7 +170,7 @@ module LogStash::PluginMixins::Jdbc
     begin
       @database.test_connection
     rescue Sequel::DatabaseConnectionError => e
-      @logger.warn("Failed test_connection.")
+      @logger.warn("Failed test_connection.", :exception => e)
       close_jdbc_connection
 
       #TODO return false and let the plugin raise a LogStash::ConfigurationError

--- a/lib/logstash/plugin_mixins/jdbc.rb
+++ b/lib/logstash/plugin_mixins/jdbc.rb
@@ -205,7 +205,11 @@ module LogStash::PluginMixins::Jdbc
 
   public
   def close_jdbc_connection
-    @database.disconnect if @database
+    begin
+      @database.disconnect if @database
+    rescue => e
+      @logger.warn("Failed to close connection", :exception => e)
+    end
     @database = nil
   end
 

--- a/logstash-input-jdbc.gemspec
+++ b/logstash-input-jdbc.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-input-jdbc'
-  s.version         = '4.2.3'
+  s.version         = '4.2.4'
   s.licenses = ['Apache License (2.0)']
   s.summary = "This example input streams a string at a definable interval."
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
The jdbc input pluging recently got support for automatically reconnecting when a database connection is lost. In this case it tries to cleanly close the old connection by calling disconnect, then setting its @database reference to nil.
@database being nil is then used as an indication that a new connection needs to be opened.
Calling disconnect leads to a call to java.sql.Connection.close() which may throw an SQLException.

In that case @database remains a reference to the broken connection and we try to reuse that.

This PR adds an exception handler to ensure that the database connection is marked dead even when disconnect throws an exception.

