### PR TITLE
Travis - add 6.0 build and remove default JRuby 1.7 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,15 +2,14 @@
 sudo: false
 language: ruby
 cache: bundler
-env: 
-rvm:
-- jruby-1.7.25
 matrix:
   include:
-  - rvm: jruby-9.1.10.0
+  - rvm: jruby-9.1.13.0
     env: LOGSTASH_BRANCH=master
-  - rvm: jruby-9.1.10.0
+  - rvm: jruby-9.1.13.0
     env: LOGSTASH_BRANCH=6.x
+  - rvm: jruby-9.1.13.0
+    env: LOGSTASH_BRANCH=6.0
   - rvm: jruby-1.7.25
     env: LOGSTASH_BRANCH=5.6
   fast_finish: true


### PR DESCRIPTION
This change was motivated by https://github.com/elastic/logstash/issues/8518 since when run without the LOGSTASH_BRANCH  environment specified, it pulls the latest released dev-utils, which in turn pulls the 5.5.1-snapshot of logstash core which is now incompatible with 1.3.5 of dev-utils. 

Rather then untangling the knot that is devutils.... this change side steps the issues by simply deferring the supported pipeline build dependency resolution which should always work, else the main build is broken.

We are loosing testing against a 'release' version of logstash, but in actuality, we are only loosing testing against 5.5.1-snapshot due to the incorrect dependency convergence of dev-utils. 