### PR TITLE
Fix connection and memory leak on pipeline reload.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.3.2
+  - [#251](https://github.com/logstash-plugins/logstash-input-jdbc/issues/251) Fix connection and memory leak.
+  
 ## 4.3.1
   - Update gemspec summary
 

--- a/lib/logstash/inputs/jdbc.rb
+++ b/lib/logstash/inputs/jdbc.rb
@@ -259,9 +259,8 @@ class LogStash::Inputs::Jdbc < LogStash::Inputs::Base
   end # def run
 
   def stop
-    @scheduler.stop if @scheduler
-
     close_jdbc_connection
+    @scheduler.stop if @scheduler
   end
 
   private

--- a/logstash-input-jdbc.gemspec
+++ b/logstash-input-jdbc.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-input-jdbc'
-  s.version         = '4.3.1'
+  s.version         = '4.3.2'
   s.licenses = ['Apache License (2.0)']
   s.summary = "Creates events from JDBC data"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
When the pipeline reload thread closes the connection, but the connection is still active (becuase is executing a query), the connection and associated memory will leak. The underlying library does not make any assurances that the connection will indeed be closed if currently in use, and observation shows this to be true. The fix here is to ensure that the a thread can not attempt close the connection (it will block) while the connection is in use. In this case that thread is the pipeline thread and the reload will now block until the current query finishes (or errors).

Fixes #251

Youkit evidence of connection behaving correctly.

A few minutes in with a couple reloads:
<img width="1265" alt="image" src="https://user-images.githubusercontent.com/976291/33690086-8b0becd4-daa7-11e7-9a51-47ff34f33aa8.png">

~30 minutes with ~30 reloads
<img width="1266" alt="image" src="https://user-images.githubusercontent.com/976291/33690094-92d9f2b2-daa7-11e7-8125-08c83bdc8815.png">

The uncollected memory still grew some...but not nearly as much as it did prior.  
