### PR TITLE
Fix thread and memory leak on pipeline reload.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.3.3
+  - [#255](https://github.com/logstash-plugins/logstash-input-jdbc/issues/255) Fix thread and memory leak.
+  
 ## 4.3.2
   - [#251](https://github.com/logstash-plugins/logstash-input-jdbc/issues/251) Fix connection and memory leak.
   

--- a/lib/logstash/inputs/jdbc.rb
+++ b/lib/logstash/inputs/jdbc.rb
@@ -260,7 +260,7 @@ class LogStash::Inputs::Jdbc < LogStash::Inputs::Base
 
   def stop
     close_jdbc_connection
-    @scheduler.stop if @scheduler
+    @scheduler.shutdown(:wait) if @scheduler
   end
 
   private

--- a/logstash-input-jdbc.gemspec
+++ b/logstash-input-jdbc.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-input-jdbc'
-  s.version         = '4.3.2'
+  s.version         = '4.3.3'
   s.licenses = ['Apache License (2.0)']
   s.summary = "Creates events from JDBC data"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
When a pipeline is reloaded, the rufus stop/shutdown method is called without any arguments. This instructs rufus to leave it's worker threads running. To fully shutdown the rufus worker threads, a :wait or :kill is needed. This change sends the :wait parameter to the shutdown method to ensure that the work thread is stopped. Prior to this change, the thread and all associated memory would stay in the JVM indefinitely.

Fixes #255
