### PR TITLE
 Enable pagination through conditions on primary key in WHERE clause

### DIFF
--- a/lib/logstash/inputs/jdbc.rb
+++ b/lib/logstash/inputs/jdbc.rb
@@ -143,6 +143,9 @@ class LogStash::Inputs::Jdbc < LogStash::Inputs::Base
   # here, ":target_id" is a named parameter. You can configure named parameters
   # with the `parameters` setting.
   config :statement, :validate => :string
+  
+  # Statement to execute that will determine the highest used id
+  config :highest_id_statement, :validate => :string
 
   # Path of file containing statement to execute
   config :statement_filepath, :validate => :path
@@ -181,6 +184,9 @@ class LogStash::Inputs::Jdbc < LogStash::Inputs::Base
   # The character encoding of all columns, leave empty if the columns are already properly UTF-8 
   # encoded. Specific columns charsets using :columns_charset can override this setting.
   config :charset, :validate => :string
+  
+  # The fully qualified name of the ID column. It is needed to decorate the SQL statement with the correct WHERE clause.
+  config :sql_id_fully_qualified_name, :validate => :string
 
   # The character encoding for specific columns. This option will override the `:charset` option 
   # for the specified columns.


### PR DESCRIPTION
Should fix https://github.com/logstash-plugins/logstash-input-jdbc/issues/166. This PR is based on the discussion that starts [HERE](https://github.com/logstash-plugins/logstash-input-jdbc/issues/166#issuecomment-326425480).

## Proposed changes:

Basically, pagination through the 'LIMIT' and 'OFFSET' clauses (or whatever is equivalent for the other supported RDBMSs) is very slow for large tables. The bigger the offset is, the longer it takes for the query to execute (because it needs to do a bigger and bigger table scan).

One solution for this is to use a condition on the primary key in the WHERE clause. This enables us to use the index of the primary key more efficiently. And make it possible to migrate large tables (millions+ rows) in a reasonable amount of time and without running into memory problems. 

In practice, let's say we are dealing with a table of 205,000 records and we have a page size of 10,000. Using offset/limit based pagination (the current approach), the plugin would execute in order these queries:
* `SELECT * FROM Items LIMIT 10000 OFFSET 0`
* `SELECT * FROM Items LIMIT 10000 OFFSET 10000`
* `SELECT * FROM Items LIMIT 10000 OFFSET 20000`
...
* `SELECT * FROM Items LIMIT 10000 OFFSET 200000`

With my changes, here are the queries that will be executed:
* `SELECT MAX(id) FROM Items` (this statement is the statement provided through the value of the new parameter `highest_id_statement`. So it is up to the user to write this statement.)
* `SELECT * FROM Items WHERE id > 0 AND id <= 10000`
* `SELECT * FROM Items WHERE id > 10000 AND id <= 20000`
* `SELECT * FROM Items WHERE id > 20000 AND id <= 30000`
...
* `SELECT * FROM Items WHERE id > 200000 AND id <= 205000`

In the new approach, each query (excluding the first statement) will roughly take the same amount of time, even with a high offset. In the current approach, queries will consume more and more time (and memory). In this way, the new approach provides a performance increase by several order of magnitude for large tables.

Relevant read: [The SQL I Love <3. Efficient pagination of a table with 100M records](http://allyouneedisbackend.com/blog/2017/09/24/the-sql-i-love-part-1-scanning-large-table/).

## Things that are left to do before this can be merged:

- [ ] The approach breaks the case where the tracking column is of type 'timestamp'. A solution should be discussed for this. Either downgrade for the offset/limit method for this case. Or unallow the tracking column to be a timestamp if pagination is to be used.