### PR TITLE
Error in default path for sql_last_valuue

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -365,7 +365,7 @@ How often to validate a connection (in seconds)
 ===== `last_run_metadata_path` 
 
   * Value type is <<string,string>>
-  * Default value is `"/home/ph/.logstash_jdbc_last_run"`
+  * Default value is `"#{ENV['HOME']}/.logstash_jdbc_last_run"`
 
 Path to file with last run time
 


### PR DESCRIPTION
I'm a first time contributor so please check if my syntax matches your style guide.
The default path for sql_last_value is listed as /home/pb/.logstash_jdbc_last_run which is INCORRECT.
This was probably the home drive of the document contributor.
The right directory is the the logstash USER's home drive. In docker it would be /usr/share/logstash/.logstash_jdbc_last_run.

I attempted to show this with "#{ENV['HOME']}"

I got this information from this forum item: https://discuss.elastic.co/t/multiple-jdbc-sql-statements-schedules-ideally/59930/3

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
