### PR TITLE
 Fix regression with 4.3.5 that can result in NULL :sql_last_value depending on timestamp forma

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.3.6
+  - [#274](https://github.com/logstash-plugins/logstash-input-jdbc/issues/274) Fix regression with 4.3.5 that can result in NULL :sql_last_value depending on timestamp format
+  
 ## 4.3.5
   - [#140](https://github.com/logstash-plugins/logstash-input-jdbc/issues/140) Fix long standing bug where setting jdbc_default_timezone loses milliseconds. Force all usage of sql_last_value to be typed according to the settings.
 

--- a/lib/logstash/plugin_mixins/value_tracking.rb
+++ b/lib/logstash/plugin_mixins/value_tracking.rb
@@ -69,6 +69,8 @@ module LogStash module PluginMixins
     def set_value(value)
       if value.respond_to?(:to_datetime)
         @value = value.to_datetime
+      else
+        @value = DateTime.parse(value)
       end
     end
   end
@@ -81,6 +83,8 @@ module LogStash module PluginMixins
     def set_value(value)
       if value.respond_to?(:to_time)
         @value = value.to_time
+      else
+        @value = DateTime.parse(value).to_time
       end
     end
   end

--- a/logstash-input-jdbc.gemspec
+++ b/logstash-input-jdbc.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-input-jdbc'
-  s.version         = '4.3.5'
+  s.version         = '4.3.6'
   s.licenses = ['Apache License (2.0)']
   s.summary = "Creates events from JDBC data"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/inputs/jdbc_spec.rb
+++ b/spec/inputs/jdbc_spec.rb
@@ -259,6 +259,8 @@ describe LogStash::Inputs::Jdbc do
       end
 
       plugin.stop
+      runner.join
+      Timecop.return
     end
 
   end
@@ -410,6 +412,7 @@ describe LogStash::Inputs::Jdbc do
         event = queue.pop
         expect(event.get("num")).to eq(12)
         expect(event.get("custom_time").time).to eq(Time.iso8601("2015-01-02T03:21:21.000Z"))
+        Timecop.return
       end
     end
 


### PR DESCRIPTION
The specs without the code fix illustrates the issue. 

There is also a minor fix to the tests included in this PR to reset Timecop (it was causing intermittent failures of the new specs). 