### PR TITLE
Load the driver with the system class loader. Fixes issue loading some JDBC drivers in Logstash 6.2+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.3.7
+  - [#263](https://github.com/logstash-plugins/logstash-input-jdbc/issues/263) Load the driver with the system class loader. Fixes issue loading some JDBC drivers in Logstash 6.2+ 
+
 ## 4.3.6
   - [#274](https://github.com/logstash-plugins/logstash-input-jdbc/issues/274) Fix regression with 4.3.5 that can result in NULL :sql_last_value depending on timestamp format
   

--- a/lib/logstash/plugin_mixins/jdbc.rb
+++ b/lib/logstash/plugin_mixins/jdbc.rb
@@ -135,7 +135,8 @@ module LogStash::PluginMixins::Jdbc
   def load_drivers(drivers)
     drivers.each do |driver|
       begin
-        require driver
+        class_loader = java.lang.ClassLoader.getSystemClassLoader().to_java(java.net.URLClassLoader)
+        class_loader.add_url(java.io.File.new(driver).toURI().toURL())
       rescue => e
         @logger.error("Failed to load #{driver}", :exception => e)
       end

--- a/logstash-input-jdbc.gemspec
+++ b/logstash-input-jdbc.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-input-jdbc'
-  s.version         = '4.3.6'
+  s.version         = '4.3.7'
   s.licenses = ['Apache License (2.0)']
   s.summary = "Creates events from JDBC data"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Fixes #263

