### PR TITLE
Update the documentation to generalize the PATH location

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -366,7 +366,7 @@ How often to validate a connection (in seconds)
 ===== `last_run_metadata_path`
 
   * Value type is <<string,string>>
-  * Default value is `"/home/ph/.logstash_jdbc_last_run"`
+  * Default value is `"$HOME/.logstash_jdbc_last_run"`
 
 Path to file with last run time
 


### PR DESCRIPTION
The documentation was generated from the ruby code on my machine, which
mean the default value was reflected the location on my laptop.