### PR TITLE
Pin tzinfo gem to a version lower than 2.0.0

### DIFF
--- a/logstash-input-jdbc.gemspec
+++ b/logstash-input-jdbc.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
   s.add_runtime_dependency 'logstash-codec-plain'
   s.add_runtime_dependency 'sequel'
-  s.add_runtime_dependency 'tzinfo'
+  s.add_runtime_dependency 'tzinfo', '< 2.0.0'
   s.add_runtime_dependency 'tzinfo-data'
   s.add_runtime_dependency 'rufus-scheduler'
 

--- a/logstash-input-jdbc.gemspec
+++ b/logstash-input-jdbc.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
   s.add_runtime_dependency 'logstash-codec-plain'
   s.add_runtime_dependency 'sequel'
-  s.add_runtime_dependency 'tzinfo', '< 2.0.0'
+  s.add_runtime_dependency 'tzinfo', '~> 1.2'
   s.add_runtime_dependency 'tzinfo-data'
   s.add_runtime_dependency 'rufus-scheduler'
 


### PR DESCRIPTION
Fixes: #325

Version 2.0.0 of this gem has been released with a lot of backwards
incompatible changes. The main known one currently being that
`utc_total_offset_rational` has been deprecated in favour of
`observed_utc_offset`.