### PR TITLE
Fix driver class loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.3.18
+  - Fix issue with driver loading [#356](https://github.com/logstash-plugins/logstash-input-jdbc/pull/356)
+
 ## 4.3.17
   - Added documentation to provide more info about jdbc driver loading [#352](https://github.com/logstash-plugins/logstash-input-jdbc/pull/352)
 

--- a/ci/unit/Dockerfile
+++ b/ci/unit/Dockerfile
@@ -3,6 +3,7 @@ FROM docker.elastic.co/logstash/logstash:$ELASTIC_STACK_VERSION
 COPY --chown=logstash:logstash Gemfile /usr/share/plugins/plugin/Gemfile
 COPY --chown=logstash:logstash *.gemspec /usr/share/plugins/plugin/
 RUN cp /usr/share/logstash/logstash-core/versions-gem-copy.yml /usr/share/logstash/versions.yml
+RUN curl -o /usr/share/logstash/postgresql.jar https://jdbc.postgresql.org/download/postgresql-42.2.8.jar
 ENV PATH="${PATH}:/usr/share/logstash/vendor/jruby/bin"
 ENV LOGSTASH_SOURCE="1"
 RUN gem install bundler -v '< 2'

--- a/ci/unit/docker-compose.yml
+++ b/ci/unit/docker-compose.yml
@@ -15,3 +15,10 @@ services:
       LS_JAVA_OPTS: "-Xmx256m -Xms256m"
       LOGSTASH_SOURCE: 1
     tty: true
+
+  postgresql:
+    image: postgres:latest
+    volumes:
+    - ./setup.sql:/docker-entrypoint-initdb.d/init.sql
+    ports:
+      - 5432:5432

--- a/ci/unit/run.sh
+++ b/ci/unit/run.sh
@@ -5,4 +5,4 @@ set -ex
 
 export USER='logstash'
 
-bundle exec rspec -fd 2>/dev/null
+bundle exec rspec spec && bundle exec rspec spec/inputs/integ_spec.rb --tag integration -fd 2>/dev/null

--- a/ci/unit/setup.sql
+++ b/ci/unit/setup.sql
@@ -1,0 +1,12 @@
+create DATABASE jdbc_input_db;
+
+\c jdbc_input_db;
+
+CREATE TABLE employee (
+   emp_no integer NOT NULL,
+   first_name VARCHAR (50) NOT NULL,
+   last_name VARCHAR (50) NOT NULL
+);
+
+INSERT INTO employee VALUES (1, 'David', 'Blenkinsop');
+INSERT INTO employee VALUES (2, 'Mark', 'Guckenheimer');

--- a/lib/logstash/plugin_mixins/jdbc/jdbc.rb
+++ b/lib/logstash/plugin_mixins/jdbc/jdbc.rb
@@ -140,28 +140,18 @@ module LogStash  module PluginMixins module Jdbc
 
     private
 
-    def load_drivers
-      return if @jdbc_driver_library.nil? || @jdbc_driver_library.empty?
-
-      driver_jars = @jdbc_driver_library.split(",")
-
-      # Needed for JDK 11 as the DriverManager has a different ClassLoader than Logstash
-      urls = java.net.URL[driver_jars.length].new
-
-      driver_jars.each_with_index do |driver, idx|
-        urls[idx] = java.io.File.new(driver).toURI().toURL()
-      end
-      ucl = java.net.URLClassLoader.new_instance(urls)
-      begin
-        klass = java.lang.Class.forName(@jdbc_driver_class.to_java(:string), true, ucl);
-      rescue Java::JavaLang::ClassNotFoundException => e
-        raise LogStash::Error, "Unable to find driver class via URLClassLoader in given driver jars: #{@jdbc_driver_class}"
-      end
-      begin
-        driver = klass.getConstructor().newInstance();
-        java.sql.DriverManager.register_driver(WrappedDriver.new(driver.to_java(java.sql.Driver)).to_java(java.sql.Driver))
-      rescue Java::JavaSql::SQLException => e
-        raise LogStash::Error, "Unable to register driver with java.sql.DriverManager using WrappedDriver: #{@jdbc_driver_class}"
+    def load_driver_jars
+      unless @jdbc_driver_library.nil? || @jdbc_driver_library.empty?
+        @jdbc_driver_library.split(",").each do |driver_jar|
+          begin
+            @logger.debug("loading #{driver_jar}")
+            # Use https://github.com/jruby/jruby/wiki/CallingJavaFromJRuby#from-jar-files to make classes from jar
+            # available
+            require driver_jar
+          rescue LoadError => e
+            raise LogStash::PluginLoadingError, "unable to load #{driver_jar} from :jdbc_driver_library, #{e.message}"
+          end
+        end
       end
     end
 
@@ -174,7 +164,7 @@ module LogStash  module PluginMixins module Jdbc
       Sequel.application_timezone = @plugin_timezone.to_sym
       if @drivers_loaded.false?
         begin
-          load_drivers
+          load_driver_jars
           Sequel::JDBC.load_driver(@jdbc_driver_class)
         rescue LogStash::Error => e
           # raised in load_drivers, e.cause should be the caught Java exceptions

--- a/logstash-input-jdbc.gemspec
+++ b/logstash-input-jdbc.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-input-jdbc'
-  s.version         = '4.3.17'
+  s.version         = '4.3.18'
   s.licenses = ['Apache License (2.0)']
   s.summary = "Creates events from JDBC data"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/logstash-input-jdbc.gemspec
+++ b/logstash-input-jdbc.gemspec
@@ -28,5 +28,4 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'logstash-devutils'
   s.add_development_dependency 'timecop'
   s.add_development_dependency 'jdbc-derby'
-  s.add_development_dependency 'jdbc-postgres'
 end

--- a/spec/inputs/jdbc_spec.rb
+++ b/spec/inputs/jdbc_spec.rb
@@ -2,8 +2,6 @@
 require "logstash/devutils/rspec/spec_helper"
 require "logstash/inputs/jdbc"
 require "jdbc/derby"
-require 'jdbc/postgres'
-Jdbc::Postgres.load_driver
 require "sequel"
 require "sequel/adapters/jdbc"
 require "timecop"
@@ -75,24 +73,6 @@ describe LogStash::Inputs::Jdbc do
         }
       end
       let(:config) { mixin_settings.merge(settings) }
-    end
-  end
-
-  context "when connecting to a non-existent server", :no_connection => true do
-    let(:mixin_settings) do
-      super.merge(
-        "jdbc_driver_class" => "org.postgresql.Driver",
-        "jdbc_connection_string" => "jdbc:postgresql://localhost:65000/somedb"
-      )
-    end
-    let(:settings) { super.merge("statement" => "SELECT 1 as col1 FROM test_table", "jdbc_user" => "foo", "jdbc_password" => "bar") }
-
-    it "should not register correctly" do
-        plugin.register
-        q = Queue.new
-        expect do
-          plugin.run(q)
-        end.to raise_error(::Sequel::DatabaseConnectionError)
     end
   end
 


### PR DESCRIPTION
The changes to class loading intended to fix usage of :jdbc_driver_library with
Java 11, introduced in `v4.3.14`, appear to have some issues
(https://github.com/elastic/logstash/issues/11268, #355). This commit attempts
to resolve those issues, and reworks the integration tests to work with
docker and ensure that the :jdbc_driver_library configuration option works.

This has been tested with postgresql using Java 8 and Java 11.

