### PR TITLE
Fix jdbc_fetch_size usage with postgresql

### DIFF
--- a/lib/logstash/plugin_mixins/jdbc/jdbc.rb
+++ b/lib/logstash/plugin_mixins/jdbc/jdbc.rb
@@ -160,6 +160,7 @@ module LogStash  module PluginMixins module Jdbc
       require "java"
       require "sequel"
       require "sequel/adapters/jdbc"
+      require "sequel/adapters/jdbc/transactions"
 
       Sequel.application_timezone = @plugin_timezone.to_sym
       if @drivers_loaded.false?
@@ -183,6 +184,7 @@ module LogStash  module PluginMixins module Jdbc
       end
       @database = jdbc_connect()
       @database.extension(:pagination)
+      @database.extend(Sequel::JDBC::Transactions)
       if @jdbc_default_timezone
         @database.extension(:named_timezones)
         @database.timezone = @jdbc_default_timezone

--- a/spec/inputs/jdbc_spec.rb
+++ b/spec/inputs/jdbc_spec.rb
@@ -970,7 +970,6 @@ describe LogStash::Inputs::Jdbc do
       {
         "statement" => "SELECT * FROM test_table",
         "jdbc_pool_timeout" => 0,
-        "jdbc_connection_string" => 'mock://localhost:1527/db',
         "sequel_opts" => {
           "max_connections" => 1
         }
@@ -1026,7 +1025,7 @@ describe LogStash::Inputs::Jdbc do
     end
 
     it "should report the statements to logging" do
-      expect(plugin.logger).to receive(:debug).once
+      expect(plugin.logger).to receive(:debug).thrice
       plugin.run(queue)
     end
   end


### PR DESCRIPTION
Credit to @phillycheeze 

Rebase of https://github.com/logstash-plugins/logstash-input-jdbc/pull/200


According to documentation (https://jdbc.postgresql.org/documentation/head/query.html) we need autocommit disabled. Work around is to create transaction and rollback always.



Will fix tests and get back to y'all.