### PR TITLE
Fix saving pipeline state using record_last_run setting

### DIFF
--- a/lib/logstash/plugin_mixins/jdbc/jdbc.rb
+++ b/lib/logstash/plugin_mixins/jdbc/jdbc.rb
@@ -252,7 +252,7 @@ module LogStash  module PluginMixins module Jdbc
       rescue Sequel::DatabaseConnectionError, Sequel::DatabaseError, Java::JavaSql::SQLException => e
         @logger.warn("Exception when executing JDBC query", :exception => e)
       else
-        @value_tracker.set_value(sql_last_value)
+        @value_tracker.set_value(sql_last_value) if @record_last_run
       ensure
         close_jdbc_connection
         @connection_lock.unlock


### PR DESCRIPTION
This fixes the issue with clean run: https://github.com/logstash-plugins/logstash-input-jdbc/issues/373

The state should not be written if the **record_last_run** setting is **false**.
